### PR TITLE
Use the one standard name for the test function. Saves duplicate code…

### DIFF
--- a/tests/test_half_duplex_combined.py
+++ b/tests/test_half_duplex_combined.py
@@ -28,7 +28,7 @@ def do_test(baud, parity):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for parity in ["UART_PARITY_EVEN", "UART_PARITY_ODD", "UART_PARITY_NONE"]:
         for baud in [57600, 115200]:
             do_test(baud, parity)

--- a/tests/test_half_duplex_rx_uart.py
+++ b/tests/test_half_duplex_rx_uart.py
@@ -26,6 +26,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [115200]:
         do_test(baud)

--- a/tests/test_half_duplex_tx_uart.py
+++ b/tests/test_half_duplex_tx_uart.py
@@ -27,7 +27,7 @@ def do_test(baud, parity):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [115200, 57600, 28800]:
         for parity in ['UART_PARITY_NONE', 'UART_PARITY_EVEN', 'UART_PARITY_ODD']:
             do_test(baud, parity)

--- a/tests/test_loopback_uart.py
+++ b/tests/test_loopback_uart.py
@@ -31,6 +31,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 28800, 57600, 115200]:
         do_test(baud)

--- a/tests/test_rx_bad_uart.py
+++ b/tests/test_rx_bad_uart.py
@@ -27,6 +27,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200]:
         do_test(baud)

--- a/tests/test_rx_bpb_uart.py
+++ b/tests/test_rx_bpb_uart.py
@@ -29,7 +29,7 @@ def do_test(baud, parity, bpb):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 57600, 115200]:
         for parity in ['UART_PARITY_NONE', 'UART_PARITY_ODD', 'UART_PARITY_EVEN']:
             for bpb in [5, 7, 8]:

--- a/tests/test_rx_intermittent.py
+++ b/tests/test_rx_intermittent.py
@@ -29,6 +29,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200]:
         do_test(baud)

--- a/tests/test_rx_large_uart.py
+++ b/tests/test_rx_large_uart.py
@@ -27,7 +27,7 @@ def do_test(baud, parity):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for parity in ['UART_PARITY_EVEN', 'UART_PARITY_ODD', 'UART_PARITY_NONE']:
         for baud in [57600, 115200]:
             do_test(baud, parity)

--- a/tests/test_rx_multi_uart.py
+++ b/tests/test_rx_multi_uart.py
@@ -31,7 +31,7 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200]:
 #    for baud in [115200]:
         do_test(baud)

--- a/tests/test_rx_parity_uart.py
+++ b/tests/test_rx_parity_uart.py
@@ -28,7 +28,7 @@ def do_test(baud, parity):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for parity in ['UART_PARITY_EVEN', 'UART_PARITY_ODD', 'UART_PARITY_NONE']:
         for baud in [14400, 28800, 57600, 115200]:
             do_test(baud, parity)

--- a/tests/test_rx_stopbits_uart.py
+++ b/tests/test_rx_stopbits_uart.py
@@ -28,7 +28,7 @@ def do_test(baud, stopbits):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 57600, 115200]:
         for stopbits in [1, 2, 3]:
             do_test(baud, stopbits)

--- a/tests/test_rx_uart.py
+++ b/tests/test_rx_uart.py
@@ -26,6 +26,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 28800, 57600, 115200]:
         do_test(baud)

--- a/tests/test_tx_bpb_uart.py
+++ b/tests/test_tx_bpb_uart.py
@@ -27,7 +27,7 @@ def do_test(baud, parity, bpb):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [115200, 230400]:
         for parity in ['UART_PARITY_NONE', 'UART_PARITY_EVEN', 'UART_PARITY_ODD']:
             for bpb in [5, 7, 8]:

--- a/tests/test_tx_buffered.py
+++ b/tests/test_tx_buffered.py
@@ -26,6 +26,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200, 230400]:
         do_test(baud)

--- a/tests/test_tx_fast_uart.py
+++ b/tests/test_tx_fast_uart.py
@@ -27,7 +27,7 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     return False
     # for baud in [230400, 460800, 921600]:
     # do_test(baud)

--- a/tests/test_tx_intermittent_uart.py
+++ b/tests/test_tx_intermittent_uart.py
@@ -27,6 +27,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200, 230400]:
         do_test(baud)

--- a/tests/test_tx_multi_uart.py
+++ b/tests/test_tx_multi_uart.py
@@ -29,7 +29,7 @@ def do_test(baud, internal_clock):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200]:
         for internal_clock in [0, 1]:
             do_test(baud, internal_clock)

--- a/tests/test_tx_parity_uart.py
+++ b/tests/test_tx_parity_uart.py
@@ -27,7 +27,7 @@ def do_test(baud, parity):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 57600, 115200, 230400]:
         for parity in ['UART_PARITY_NONE', 'UART_PARITY_EVEN', 'UART_PARITY_ODD']:
             do_test(baud, parity)

--- a/tests/test_tx_stopbits_uart.py
+++ b/tests/test_tx_stopbits_uart.py
@@ -28,7 +28,7 @@ def do_test(baud, stopbits):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [14400, 57600, 115200, 230400]:
         for stopbits in [1, 2, 3]:
             do_test(baud, stopbits)

--- a/tests/test_tx_uart.py
+++ b/tests/test_tx_uart.py
@@ -26,6 +26,6 @@ def do_test(baud):
                               build_env=myenv)
 
 
-def runtests():
+def runtest():
     for baud in [57600, 115200, 230400]:
         do_test(baud)

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -15,7 +15,7 @@ class UartTester(xmostest.Tester):
                                  {}, result, output=''.join(output))
 
 
-def runtests():
+def runtest():
     resources = xmostest.request_resource("xsim")
     # xmostest.run_on_simulator(resources['xsim'],
     #                           'app_uart_test/bin/smoke/app_uart_test_smoke.xe',


### PR DESCRIPTION
… in tools_xmostest.